### PR TITLE
Added CLI functionality to `fontresoft`

### DIFF
--- a/lib/copier.dart
+++ b/lib/copier.dart
@@ -1,0 +1,210 @@
+import 'dart:io';
+
+import 'package:ansi_styles/ansi_styles.dart';
+import 'package:fontresoft/src/exception.dart';
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart';
+import 'package:yaml_writer/yaml_writer.dart';
+
+class Copier {
+  final String configFilePath;
+
+  Copier(this.configFilePath);
+
+  Future<void> loadConfig() async {
+    final file = File(configFilePath);
+    if (!file.existsSync()) {
+      throw ConfigException("Configuration file `$configFilePath` not found");
+    }
+
+    final contents = await file.readAsString();
+    final yamlMap = loadYaml(contents);
+
+    if (yamlMap == null || !yamlMap.containsKey('fonts')) {
+      throw ConfigException("Invalid configuration file `$configFilePath`");
+    }
+  }
+
+  Future<List<String>> loadFontFamilies() async {
+    final file = File(configFilePath);
+    final contents = await file.readAsString();
+    final yamlMap = loadYaml(contents) as YamlMap?;
+
+    if (yamlMap == null || !yamlMap.containsKey('fonts')) {
+      throw CopierException("Invalid configuration file `$configFilePath`");
+    }
+
+    final fonts = yamlMap['fonts'] as List<dynamic>;
+    return List<String>.from(fonts);
+  }
+
+  List<String> findFontFiles(String fontFamily, String packagePath, YamlMap pubspecYaml) {
+    final fonts = pubspecYaml['flutter']?['fonts'] as List? ?? [];
+    final fontPaths = <String>[];
+
+    for (var font in fonts) {
+      if (font['family'] == fontFamily) {
+        final fontAssets = font['fonts'] as List? ?? [];
+        for (var fontAsset in fontAssets) {
+          String assetPath = fontAsset['asset'] as String;
+          assetPath = assetPath.replaceFirst('packages/fontresoft/', 'lib/');
+          fontPaths.add(path.join(packagePath, assetPath).fixPath);
+        }
+        break;
+      }
+    }
+
+    return fontPaths;
+  }
+
+  void copyFonts(List<String> fontFiles, String fontFamily, String outputDirPath) {
+    final outputDir = Directory(outputDirPath);
+    if (!outputDir.existsSync()) {
+      outputDir.createSync(recursive: true);
+    }
+    if (fontFiles.isNotEmpty) {
+      for (var fontFile in fontFiles) {
+        final file = File(fontFile);
+        if (!file.existsSync()) {
+          print("\n✖ Font file `$fontFile` not found");
+          continue;
+        }
+        final destination = path.join(outputDir.path, path.basename(fontFile)).fixPath;
+        print(AnsiStyles.blueBright("- Copying font file `${fontFile.split('/').last}` to `$destination`"));
+        try {
+          file.copySync(destination);
+        } catch (e) {
+          if (e is PathExistsException) {
+            /// Cannot create a file when that file already exists.
+            throw CopierException('${e.message}.\n'
+                '${AnsiStyles.italic("Cannot create a file when that file already exists.")}');
+          } else if (e is PathNotFoundException) {
+            /// The system cannot find the path specified.
+            throw CopierException('${e.message}.\n'
+                '${AnsiStyles.italic("-help: The system cannot find the path specified.")}');
+          } else {
+            throw CopierException(e.toString());
+          }
+        }
+      }
+    } else {
+      print(AnsiStyles.blueBright('\nWe\'re sorry, `$fontFamily` font is not yet available for fontresoft!'));
+
+      /// SEND MSG TO DEVELOPER TO ADD FONT
+    }
+  }
+
+  ({List<String> beforeFlutter, String afterFlutter}) loadYamlCustom(String yamlContent) {
+    final List<String> lines = yamlContent.split('\n');
+    final List<String> formattedLines = [];
+    final StringBuffer yamlBuffer = StringBuffer();
+    bool isBeforeFlutterSection = true;
+    bool isAfterFlutterSection = true;
+
+    for (var line in lines) {
+      if (isBeforeFlutterSection) {
+        if (line.trimRight() == 'flutter:') {
+          isBeforeFlutterSection = false;
+        } else {
+          formattedLines.add(line);
+        }
+      }
+      if (!isBeforeFlutterSection && isAfterFlutterSection) {
+        if (line.trimRight() == '  fonts:') {
+          isAfterFlutterSection = false;
+        } else {
+          yamlBuffer.writeln(line);
+        }
+      }
+    }
+
+    return (beforeFlutter: formattedLines, afterFlutter: yamlBuffer.toString());
+  }
+
+  Future<void> updatePubspec(List<String> fontFamilies, String outputDirPath, String pubspecPath) async {
+    final pubspecFile = File(pubspecPath);
+
+    // Reading the output pubspec.yaml file
+    final pubspecContent = await pubspecFile.readAsString();
+
+    // Parse the YAML content
+    final pubspecYamlCustom = loadYamlCustom(pubspecContent);
+    final pubspecYaml = loadYaml(pubspecYamlCustom.afterFlutter);
+
+    final newFontsSection = <Map<String, dynamic>>[];
+    for (var fontFamily in fontFamilies) {
+      // We can actually not copy the fonts, and then search the font files directly from the
+      // package lib/font folder using this same search
+      final fontFiles = Directory(outputDirPath.fixPath).listSync().whereType<File>().where((file) {
+        return path.basenameWithoutExtension(file.path).startsWith(fontFamily);
+      }).map((e) {
+        return File(e.path.replaceAll('\\', '/'));
+      }).toList();
+
+      final fontsList = <Map<String, dynamic>>[];
+      for (var fontFile in fontFiles) {
+        final fontWeight = path.basenameWithoutExtension(fontFile.path).split('-').last;
+        final weight = _getFontWeight(fontWeight);
+        final assetPath = path.join(outputDirPath, path.basename(fontFile.path)).fixPath;
+
+        final fontMap = {
+          'asset': assetPath,
+          if (weight != null) 'weight': weight,
+        };
+        fontsList.add(fontMap);
+      }
+      newFontsSection.add({
+        'family': fontFamily,
+        'fonts': fontsList,
+      });
+    }
+
+    final mutablePubspecYaml = Map<String, dynamic>.from(pubspecYaml ?? {});
+    final flutterSection = Map<String, dynamic>.from(mutablePubspecYaml['flutter'] ?? {});
+
+    flutterSection['fonts'] = newFontsSection;
+    mutablePubspecYaml['flutter'] = flutterSection;
+
+    StringBuffer stringBuffer = StringBuffer();
+
+    final yamlWriter = YamlWriter();
+    var newPart = yamlWriter.write(mutablePubspecYaml);
+
+    for (var o in pubspecYamlCustom.beforeFlutter) {
+      stringBuffer.writeln(o);
+    }
+
+    stringBuffer.write(newPart);
+    await pubspecFile.writeAsString(stringBuffer.toString());
+    print(AnsiStyles.greenBright.bold("\n✔ pubspec.yaml updated successfully."));
+  }
+
+  int? _getFontWeight(String fontWeight) {
+    switch (fontWeight.toLowerCase()) {
+      case 'thin':
+        return 100;
+      case 'extralight':
+        return 200;
+      case 'light':
+        return 300;
+      case 'regular':
+        return 400;
+      case 'medium':
+        return 500;
+      case 'semibold':
+        return 600;
+      case 'bold':
+        return 700;
+      case 'extrabold':
+        return 800;
+      case 'black':
+        return 900;
+      default:
+        return null;
+    }
+  }
+}
+
+extension PathExt on String {
+  String get fixPath => replaceAll('\\', '/');
+}

--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:ansi_styles/ansi_styles.dart';
+import 'package:fontresoft/src/exception.dart';
+import 'package:prompts/prompts.dart' as prompts;
+import 'package:yaml/yaml.dart';
+import 'package:yaml_writer/yaml_writer.dart';
+
+Future<void> generateConfig(String configFilePath) async {
+  final config = {'fonts': []};
+  final file = File(configFilePath);
+  if (!file.existsSync()) {
+    await writeConfigFile(file, config, configFilePath);
+  } else {
+    var decision = prompts.choose(
+      AnsiStyles.yellowBright('\nConfiguration file already exists. Do you want to overwrite it?'),
+      ['Yes', 'No'],
+      defaultsTo: 'No',
+    );
+    if (decision == 'Yes') {
+      await writeConfigFile(file, config, configFilePath);
+    } else {
+      print(AnsiStyles.cyan('\n✖ Cancelled!'));
+    }
+  }
+}
+
+Future<void> writeConfigFile(File file, Map<String, List<dynamic>> config, String configFilePath) async {
+  await file.writeAsString(YamlWriter().write(config));
+  print(AnsiStyles.greenBright.bold('\n✔ Configuration file generated at `$configFilePath`\n'));
+}
+
+Future<void> addFontToConfig(String configFilePath, List<String> fonts) async {
+  final file = File(configFilePath);
+  if (!file.existsSync()) {
+    throw ConfigException("Configuration file `$configFilePath` not found.");
+  }
+
+  final contents = await file.readAsString();
+  final yamlMap = loadYaml(contents) as YamlMap;
+
+  final updatedFonts = Set<dynamic>.from(yamlMap['fonts'] ?? [])..addAll(fonts);
+  final updatedConfig = {'fonts': updatedFonts.toList()};
+  await file.writeAsString(YamlWriter().write(updatedConfig));
+  print(AnsiStyles.greenBright.bold('\n✔ Fonts added to configuration file.\n'));
+}
+
+Future<void> removeFontFromConfig(String configFilePath, List<String> fonts) async {
+  final file = File(configFilePath);
+  if (!file.existsSync()) {
+    throw ConfigException("Configuration file `$configFilePath` not found.");
+  }
+
+  final contents = await file.readAsString();
+  final yamlMap = loadYaml(contents) as YamlMap;
+
+  final updatedFonts = List<String>.from(yamlMap['fonts'] ?? [])
+    ..removeWhere(
+      (font) => fonts.contains(font),
+    );
+  final updatedConfig = {'fonts': updatedFonts};
+  await file.writeAsString(YamlWriter().write(updatedConfig));
+  print(AnsiStyles.greenBright.bold('\n✔ ︎Fonts removed from configuration file.\n'));
+}
+
+Future<void> listFontsInConfig(String configFilePath) async {
+  final file = File(configFilePath);
+  if (!file.existsSync()) {
+    throw ConfigException("Configuration file `$configFilePath` not found.");
+  }
+
+  final contents = await file.readAsString();
+  final yamlMap = loadYaml(contents) as YamlMap;
+
+  final fonts = List<String>.from(yamlMap['fonts'] ?? []);
+  print(AnsiStyles.blueBright.bold('\nFonts in configuration file:'));
+  for (int i = 0; i < fonts.length; i++) {
+    var font = fonts[i];
+    print(AnsiStyles.magentaBright.italic('${i + 1}. $font'));
+  }
+  print('');
+}
+
+Future<void> deleteConfigFile(String configFilePath) async {
+  final file = File(configFilePath);
+  if (!file.existsSync()) {
+    throw ConfigException("Configuration file `$configFilePath` not found.");
+  }
+
+  var decision = prompts.choose(
+    AnsiStyles.yellowBright('\nAre you sure you want to delete the configuration file?'),
+    ['Yes', 'No'],
+    defaultsTo: 'No',
+  );
+  if (decision == 'Yes') {
+    await file.delete();
+    print(AnsiStyles.greenBright.bold('\n✔ Configuration file `$configFilePath` deleted \n'));
+  } else {
+    print(AnsiStyles.red('\n✖ Cancelled!'));
+  }
+}
+
+/// ✖
+/// ✔

--- a/lib/setup.dart
+++ b/lib/setup.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ansi_styles/ansi_styles.dart';
+import 'package:args/args.dart';
+import 'package:fontresoft/src/exception.dart';
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart';
+
+import 'copier.dart';
+
+class Setup {
+  static Future<void> copyAndGenerateFonts(ArgResults argResults, ArgParser parser) async {
+    final configFilePath = argResults['config'] as String?;
+    final pubspecPath = argResults['pubspec'] as String?;
+
+    if (configFilePath == null || pubspecPath == null) {
+      throw OptionException('Missing required options.');
+    }
+
+    final fontCopier = Copier(configFilePath);
+
+    try {
+      await fontCopier.loadConfig();
+      final fontFamilies = await fontCopier.loadFontFamilies();
+      final packagePath = await findPackagePath();
+      print(AnsiStyles.magentaBright("\nUsing package path: `$packagePath`"));
+
+      const assetFontDir = 'assets/fonts'; // Fixed output directory
+
+      final pubspecFile = File(path.join(packagePath, "pubspec.yaml").fixPath);
+      final pubspecContent = await pubspecFile.readAsString();
+      final pubspecYaml = loadYaml(pubspecContent) as YamlMap;
+
+      for (var fontFamily in fontFamilies) {
+        final fontFiles = fontCopier.findFontFiles(fontFamily, packagePath, pubspecYaml);
+        fontCopier.copyFonts(fontFiles, fontFamily, assetFontDir);
+      }
+
+      await fontCopier.updatePubspec(fontFamilies, assetFontDir, pubspecPath);
+      print(AnsiStyles.greenBright.bold("\n✔ Fonts copied and pubspec.yaml updated successfully.\n"));
+    } catch (e) {
+      if (e is PathNotFoundException) {
+        print(AnsiStyles.redBright('\n✖ The system cannot find the file `$pubspecPath` specified.'));
+        print(AnsiStyles.yellowBright('\nRecommendation:\n'
+            '1. Ensure that the `-p` or `--pubspec` option points to the correct location of your `pubspec.yaml` file.\n'
+            '2. If you don\'t want to modify the `pubspec.yaml` file, you can create a custom `.yaml` file manually and \n'
+            'copy the generated font map into your `pubspec.yaml` file, which is where the generated font yaml are supposed to be written.\n'));
+      } else {
+        print(AnsiStyles.redBright("\n✖ $e"));
+      }
+    }
+  }
+
+  static Future<String> findPackagePath() async {
+    final packageConfigFile = File(path.join('.dart_tool', 'package_config.json').fixPath);
+    if (!packageConfigFile.existsSync()) {
+      throw CopierException("`${packageConfigFile.path}` not found.");
+    }
+
+    final packageConfigContent = jsonDecode(await packageConfigFile.readAsString());
+    final packages = packageConfigContent['packages'] as List;
+    final package = packages.firstWhere((pkg) => pkg['name'] == 'fontresoft', orElse: () => null);
+
+    if (package == null) {
+      throw Exception("Package fontresoft not found in package_config.json.");
+    }
+
+    final rootUri = package['rootUri'] as String;
+    final packageConfigDir = packageConfigFile.parent.path;
+    final resolvedRootUri = path.normalize(path.join(packageConfigDir, rootUri)).fixPath;
+
+    return resolvedRootUri;
+  }
+}

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -1,0 +1,26 @@
+class ConfigException implements Exception {
+  final String message;
+
+  ConfigException(this.message);
+
+  @override
+  String toString() => 'ConfigException: $message';
+}
+
+class CopierException implements Exception {
+  final String message;
+
+  CopierException(this.message);
+
+  @override
+  String toString() => 'CopierException: $message';
+}
+
+class OptionException implements Exception {
+  final String message;
+
+  OptionException(this.message);
+
+  @override
+  String toString() => 'OptionException: $message';
+}

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -22,6 +22,7 @@ extension TextStyleExtension on TextStyle {
       '$path${FontResoft.sourceSansPro}' => FontResoft.sourceSansPro,
       '$path${FontResoft.sFProDisplay}' => FontResoft.sFProDisplay,
       '$path${FontResoft.sFProText}' => FontResoft.sFProText,
+      '$path${FontResoft.comfortaa}' => FontResoft.comfortaa,
       _ => throw ArgumentError("Unknown font: $fontFamily")
     };
   }

--- a/lib/src/fontresoft.dart
+++ b/lib/src/fontresoft.dart
@@ -47,6 +47,7 @@ class FontResoft {
   static const String lato = "Lato";
   static const String sFProDisplay = "SFProDisplay";
   static const String sFProText = "SFProText";
+  static const String comfortaa = "Comfortaa";
 }
 
 /// A utility class for applying text styles with specific font families.
@@ -159,5 +160,15 @@ class Font {
         fontFamily: FontResoft.sFProText, package: FontResoft.package);
     return st ??= const TextStyle().copyWith(
         fontFamily: FontResoft.sFProText, package: FontResoft.package);
+  }
+
+  /// Returns a TextStyle object with the Comfortaa font family applied.
+  ///
+  /// Optionally accepts a [style] parameter for additional text style customization.
+  static TextStyle comfortaa({TextStyle? style}) {
+    var st = style?.copyWith(
+        fontFamily: FontResoft.comfortaa, package: FontResoft.package);
+    return st ??= const TextStyle().copyWith(
+        fontFamily: FontResoft.comfortaa, package: FontResoft.package);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fontresoft
 description: FontResoft is a flutter font package compiled and arranged by us for use in any flutter project.
   It contains different beautiful fonts for building nice, eye-catchy flutter apps.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/kenresoft/fontresoft
 
 environment:
@@ -11,11 +11,21 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  yaml_writer: ^2.0.0
+  yaml: 3.1.2
+  path: 1.9.0
+  args: ^2.5.0
+  ansi_styles: ^0.3.2+1
+  io: ^1.0.4
+  prompts: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^4.0.0
+
+executables:
+  fontresoft: fontresoft
 
 flutter:
 
@@ -241,50 +251,72 @@ flutter:
     # SFProDisplay
     - family: SFProDisplay
       fonts:
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Black.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Black.otf
           weight: 900
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Bold.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Bold.otf
           weight: 700
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Heavy.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Heavy.otf
           weight: 800
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Light.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Light.otf
           weight: 300
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Medium.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Medium.otf
           weight: 500
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Regular.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Regular.otf
           weight: 400
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Semibold.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Semibold.otf
           weight: 600
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Thin.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Thin.otf
           weight: 100
           style: normal
-        - asset: packages/fontresoft/fonts/SFProDisplay/SF-Pro-Display-Ultralight.otf
+        - asset: packages/fontresoft/fonts/SFProDisplay/SFProDisplay-Ultralight.otf
           weight: 200
           style: normal
 
     # SFProText
     - family: SFProText
       fonts:
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Black.otf
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Black.otf
           weight: 900
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Bold.otf
+          style: normal
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Bold.otf
           weight: 700
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Heavy.otf
+          style: normal
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Heavy.otf
           weight: 800
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Light.otf
+          style: normal
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Light.otf
           weight: 300
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Medium.otf
+          style: normal
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Medium.otf
           weight: 500
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Regular.otf
+          style: normal
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Regular.otf
           weight: 400
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Semibold.otf
+          style: normal
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Semibold.otf
           weight: 600
-        - asset: packages/fontresoft/fonts/SFProText/SF-Pro-Text-Thin.otf
+          style: normal
+        - asset: packages/fontresoft/fonts/SFProText/SFProText-Thin.otf
           weight: 100
+          style: normal
+
+    # Comfortaa
+    - family: Comfortaa
+      fonts:
+        - asset: packages/fontresoft/fonts/Comfortaa/static/Comfortaa-Bold.ttf
+          weight: 700
+        - asset: packages/fontresoft/fonts/Comfortaa/static/Comfortaa-Light.ttf
+          weight: 300
+        - asset: packages/fontresoft/fonts/Comfortaa/static/Comfortaa-Medium.ttf
+          weight: 500
+        - asset: packages/fontresoft/fonts/Comfortaa/static/Comfortaa-Regular.ttf
+          weight: 400
+        - asset: packages/fontresoft/fonts/Comfortaa/static/Comfortaa-SemiBold.ttf
+          weight: 600


### PR DESCRIPTION
To enhance performance and optimize package size, we have introduced a powerful Command-Line Interface (CLI) in `fontresoft`. This new functionality allows developers to selectively bundle only the required fonts into their build, rather than including the entire library. With the CLI, you can now:

- Efficiently Manage Font Bundles: Access and bundle only the fonts needed for your project, reducing the overall package size.
- Improve Build Performance: Streamline your build process by eliminating unnecessary fonts, leading to faster build times and improved app performance.
- Simplify Font Integration: Easily integrate the CLI into your development workflow, ensuring that only the essential fonts are included in your final build.